### PR TITLE
Fix <leader> sy failed in zsh issue

### DIFF
--- a/ftplugin/ccvext.vim
+++ b/ftplugin/ccvext.vim
@@ -117,7 +117,7 @@ else
 endif
 "}}}
 "support postfix list {{{
-let s:postfix = ['"*.java"', '"*.h"', '"*.c"', '"*.hpp"', '"*.cpp"', '"*.cc"', '*.cs', '*.js']
+let s:postfix = ['"*.java"', '"*.h"', '"*.c"', '"*.hpp"', '"*.cpp"', '"*.cc"', '"*.cs"', '"*.js"']
 "}}}
 "Check software environment {{{
 if !executable ('ctags')


### PR DESCRIPTION
"find . -name *.cs" will fail in zsh and return error(zsh: no matches found: *.cs). So update '*.cs', '*.js' to '"*.cs"', '"*.js"'